### PR TITLE
fix : added z-index on bg-video

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -249,6 +249,7 @@ section {
   object-fit: cover;
   width: 100vw;
   height: 100vh;
+  z-index: 0;
 }
 
 .text-white {


### PR DESCRIPTION
added z-index to 0 on css class bg-video to fix the overlay animation on Capra page when changing from Robots to Capra.