### PR TITLE
39 buttons have wrong font color

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@ button:focus {
 .btn:hover,
 a:hover {
   text-decoration: none;
-  color: #f00d0d;
+  color: #fff;
 }
 
 img {


### PR DESCRIPTION
Changed the hover color for the toolbar from red to white in the App.vue styles. Worked on all the buttons on the toolbar, I verified every other button but other than the toolbar they already looked fine, never saw the text in blue like in the example for this issue. Verified in french and english to be sure.