### PR TITLE
fix: removed absolute to bar, teleport to top when change page

### DIFF
--- a/src/components/NavbarComponent.vue
+++ b/src/components/NavbarComponent.vue
@@ -66,7 +66,7 @@ function isMobile() {
     <DrawerComponent :items="pages" />
   </v-navigation-drawer>
 
-  <v-app-bar absolute density="compact" color="red">
+  <v-app-bar density="compact" color="red">
     <v-app-bar-nav-icon @click="drawer = !drawer" />
 
     <v-img

--- a/src/router.ts
+++ b/src/router.ts
@@ -21,6 +21,9 @@ const router: Router = createRouter({
    */
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
+  scrollBehavior() {
+    document.getElementById('app')?.scrollIntoView({ behavior: 'instant' });
+  },
 });
 
 // Global before guards


### PR DESCRIPTION
Removed the absolute part of the NavBar so it could follow the user when they went down the page. If you were low enough and switched pages, it was possible to be in the middle of the new one, hence why i added to the router a scrollBehavior, putting us at the top every time we switch pages. If there is another way to do this let me know i'm curious as to other ways to force the page to be on top.