### PR TITLE
63 replacing sections on the robots page for jumbotrons

### DIFF
--- a/src/components/JumbotronVideoComponent.vue
+++ b/src/components/JumbotronVideoComponent.vue
@@ -14,6 +14,11 @@ const props = defineProps<{
    * If set, the main element will have a background image.
    */
   img?: string;
+  /**
+   * If set and true, the opacity of the overlay and the size the text will change.
+   * To show the content.
+   */
+  isContent?:  boolean;
 }>();
 
 const mainElementRef = ref<HTMLElement | null>(null);

--- a/src/components/JumbotronVideoComponent.vue
+++ b/src/components/JumbotronVideoComponent.vue
@@ -32,7 +32,11 @@ if (props.img) {
 </script>
 
 <template>
-  <div ref="mainElementRef" class="jumbotron d-flex align-items-center">
+  <div
+    ref="mainElementRef"
+    :class="isContent ? 'jumbotron-content' : 'jumbotron-title'"
+    class="jumbotron d-flex align-items-center"
+  >
     <h1 class="text-md-h1 mb-4">{{ title }}</h1>
     <video v-if="video" class="bg-video" preload="true" autoplay muted>
       <source :src="video" type="video/mp4" />
@@ -60,7 +64,6 @@ if (props.img) {
   position: absolute;
   display: block;
   content: '';
-  opacity: 0.8;
   top: 0;
   bottom: 0;
   left: 0;
@@ -77,13 +80,27 @@ if (props.img) {
   line-height: 0.9;
   font-weight: bold;
   display: inline-block;
-  border: 15px solid #fff;
   padding: 30px;
-  opacity: 0;
-  animation: 1s fadeInFromTop cubic-bezier(0.785, 0.135, 0.15, 0.86) 1s forwards;
-  animation-delay: 0.2s;
   z-index: 1;
   margin-left: auto;
   margin-right: auto;
+}
+.jumbotron-title::before {
+  opacity: 0.8;
+}
+.jumbotron-content::before {
+  opacity: 0.5;
+}
+
+.jumbotron-title > h1 {
+  /* Fading animation */
+  opacity: 0;
+  animation: 1s fadeInFromTop cubic-bezier(0.785, 0.135, 0.15, 0.86) 1s forwards;
+  animation-delay: 0.2s;
+
+  border: 15px solid #fff;
+}
+.jumbotron-content > h1 {
+  font-size: 3.5rem !important;
 }
 </style>

--- a/src/views/RobotsView.vue
+++ b/src/views/RobotsView.vue
@@ -15,19 +15,19 @@ import markhorStairs from '@clubcapra/assets/media/markhor_stairs.mp4';
     <div class="section">
       <JumbotronVideoComponent :title="$t('our_robots')" :img="robotsBG" />
     </div>
-    <div class="section section-overlay">
-      <img :src="markhorSave" class="section-image" />
-      <div class="layer">
-        <h1>{{ $t('robots_save_lives') }}</h1>
-      </div>
+    <div class="section">
+      <JumbotronVideoComponent
+        :title="$t('robots_save_lives')"
+        :img="markhorSave"
+        :is-content="true"
+      />
     </div>
-    <div class="section section-overlay">
-      <video loop muted playsinline data-autoplay>
-        <source :src="homepageVid" type="video/mp4" />
-      </video>
-      <div class="layer">
-        <h1>{{ $t('robots_perform_with_precision') }}</h1>
-      </div>
+    <div class="section">
+      <JumbotronVideoComponent
+        :title="$t('robots_perform_with_precision')"
+        :video="homepageVid"
+        :is-content="true"
+      />
     </div>
     <div class="section section-overlay">
       <video


### PR DESCRIPTION
We're updating the robots page by substituting individual media sections with jumbotrons due to their consistent styling. Additionally, we're implementing a new property in the jumbotrons component to distinguish between those used for titles and those used for content.