### PR TITLE
Edit sponsors

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -8,9 +8,6 @@ import SponsorComponent from '@clubcapra/components/SponsorComponent.vue';
 import introTrimmed from '@clubcapra/assets/media/intro_trimmed.mp4';
 import prototypes from '@clubcapra/assets/media/prototypes.jpg';
 import teamcaprarobot from '@clubcapra/assets/media/teamcaprarobot.png';
-
-// Files
-import partenariatFile from '@clubcapra/assets/documents/CAPRA_PlanPartenariat.pdf';
 </script>
 
 <template>
@@ -90,13 +87,6 @@ import partenariatFile from '@clubcapra/assets/documents/CAPRA_PlanPartenariat.p
             </div>
           </div>
           <SponsorComponent />
-        </div>
-        <div class="col-md-12">
-          <div class="mt-3 text-center">
-            <a :href="partenariatFile" target="_blank" class="btn btn-primary">
-              {{ $t('btn_discover_our_partnership_plan').toUpperCase() }}
-            </a>
-          </div>
         </div>
       </div>
     </div>

--- a/src/views/PartnersView.vue
+++ b/src/views/PartnersView.vue
@@ -48,12 +48,6 @@ import odrive from '@clubcapra/assets/media/partners/odrive.png';
               alt="IXIASOFT Madcap logo RGB C"
             />
           </div>
-          <div class="col-md-6 col-12">
-            <img :src="stelpro" alt="stelpro" />
-          </div>
-          <div class="col-md-6 col-12">
-            <img :src="opnor" alt="opnor" />
-          </div>
         </div>
         <div class="title-wrap partner-title silver-title" data-aos="fade-up">
           <h2 class="section-title">{{ $t('partner_silver') }}</h2>
@@ -61,6 +55,12 @@ import odrive from '@clubcapra/assets/media/partners/odrive.png';
         <div class="row justify-content-center align-items-center py-5">
           <div class="col-md-3 col-6">
             <img :src="aeets" alt="AEETS" />
+          </div>
+          <div class="col-md-3 col-6">
+            <img :src="stelpro" alt="stelpro" />
+          </div>
+          <div class="col-md-3 col-6">
+            <img :src="opnor" alt="opnor" />
           </div>
           <div class="col-md-3 col-6">
             <img :src="altium" alt="Altium" />

--- a/src/views/PartnersView.vue
+++ b/src/views/PartnersView.vue
@@ -2,9 +2,6 @@
 import partnerHandshake from '@clubcapra/assets/media/partners-handshake.jpg';
 import JumbotronVideoComponent from '@clubcapra/components/JumbotronVideoComponent.vue';
 
-// Documents
-import planPartenariat from '@clubcapra/assets/documents/CAPRA_PlanPartenariat.pdf';
-
 // Partners logos
 import hsLogoCouleur from '@clubcapra/assets/media/partners/HS_logo_couleur.png';
 import ixiasoftMadcapLogoRgbC from '@clubcapra/assets/media/partners/IXIASOFT-Madcap-logo-RGB-C.jpg';
@@ -84,16 +81,6 @@ import odrive from '@clubcapra/assets/media/partners/odrive.png';
           </div>
           <div class="col-md-2 col-4">
             <img :src="odrive" alt="odrive" />
-          </div>
-        </div>
-        <div class="col-md-12">
-          <div class="mt-3 text-center">
-            <!--
-              **Removal of partnership plan for a short moment. WIP -- will be added back by march 1st**
-            <a class="btn btn-primary" :href="planPartenariat" target="_blank">
-              {{ $t('discover_our_partnership').toUpperCase() }}
-            </a>
-            -->
           </div>
         </div>
       </div>

--- a/src/views/PartnersView.vue
+++ b/src/views/PartnersView.vue
@@ -88,9 +88,12 @@ import odrive from '@clubcapra/assets/media/partners/odrive.png';
         </div>
         <div class="col-md-12">
           <div class="mt-3 text-center">
+            <!--
+              **Removal of partnership plan for a short moment. WIP -- will be added back by march 1st**
             <a class="btn btn-primary" :href="planPartenariat" target="_blank">
               {{ $t('discover_our_partnership').toUpperCase() }}
             </a>
+            -->
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Urgent Removal of Partnership Plan Button

### Summary
This pull request removes the "Discover Our Partnership Plan" button from the partners' page. The current partnership plan document is outdated, and it's crucial that we prevent access to it until the new version is ready.

### Changes
- Commented out the button that links to the partnership plan PDF to prevent users from accessing the outdated information.
- Adjusted the sponsor tiers to reflect our current partners' status.

### Rationale
The partnership plan is being revised, and we've had instances of partners and potential partners viewing outdated information. To maintain the integrity of our communication and prevent confusion, we need to remove this button as soon as possible. We will reintroduce the button along with the updated partnership plan once it's ready for public release.

### Next Steps
- The team is currently updating the partnership plan.
- Once the new plan is finalized and approved, we will update the link and uncomment the button to make it accessible again.
- Monitor any feedback from partners about the missing button and inform them about the update in progress.