### PR TITLE
Change tint values on pictures and videos of markhor

### DIFF
--- a/src/components/JumbotronVideoComponent.vue
+++ b/src/components/JumbotronVideoComponent.vue
@@ -55,7 +55,7 @@ if (props.img) {
   position: absolute;
   display: block;
   content: '';
-  opacity: 0.8;
+  opacity: 0.3;
   top: 0;
   bottom: 0;
   left: 0;

--- a/src/views/RobotsView.vue
+++ b/src/views/RobotsView.vue
@@ -63,14 +63,14 @@ import markhorStairs from '@clubcapra/assets/media/markhor_stairs.mp4';
   padding: 1rem;
   margin-bottom: 1rem;
   color: white;
-  opacity: 0.9;
+  opacity: 0.4;
 }
 
 .section-overlay:before {
   position: absolute;
   display: block;
   content: '';
-  opacity: 0.5;
+  opacity: 0.4;
   top: 0;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
Change tint values.

Why: The videos of Markhor were really tinted, which made it hard to see him in action. Now he can be happy, as we can all see him clearly